### PR TITLE
Removed redundant conversion to string in config.py

### DIFF
--- a/data/config.py
+++ b/data/config.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-BOT_TOKEN = str(os.getenv("BOT_TOKEN"))
+BOT_TOKEN = os.getenv("BOT_TOKEN")
 
 admins = [
     os.getenv("ADMIN_ID"),


### PR DESCRIPTION
According to [os.getenv()](https://docs.python.org/3/library/os.html#os.getenv) documentation, a string is returned, no need to wrap the result in `str()` again.